### PR TITLE
python 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 os:
   - linux
 python:
+  - "2.7"
+  - "3.5"
   - "3.6"
 script:
   - pytest --cov=birdbrain --current-env

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ birdbrain
 
 Tim Sainburg & Marvin Thielk
 
-This is a small library for viewing the [songbird/bat brain atlases](https://www.uantwerpen.be/en/research-groups/bio-imaging-lab/research/mri-atlases/starling-brain-atlas/) (Poirier et al., 2008; De Groof et al., 2016; Vellema et al., 2011; Gunturken et al., 2013; Washington et al., 2018). It currently has examples of European starling, Canary, Zebra finch, Mustached bat, and Pigeon brain atlases. 
+This is a small library for viewing the [songbird/bat brain atlases](https://www.uantwerpen.be/en/research-groups/bio-imaging-lab/research/mri-atlases/starling-brain-atlas/) (Poirier et al., 2008; De Groof et al., 2016; Vellema et al., 2011; Güntürkün et al., 2013; Washington et al., 2018). It currently has examples of European starling, Canary, Zebra finch, Mustached bat, and Pigeon brain atlases. 
 
 The package can do things like:
 
-- nuclei localization relative to a set stereotaxic reference point (e.g. y-sinus in starlings)
-- 3d printing an STL of the brains
+- Nuclei localization relative to a set stereotaxic reference point (e.g. y-sinus in starlings).
+- 3D printing an STL of the brains.
 - Plotting recording locations in 2d and 3d on imaging data. 
-- Creating visualizations / movies videos of nuclei of interest
+- Creating visualizations / movies videos of nuclei of interest.
 
 There is an [online interactive demo](https://mybinder.org/v2/gh/timsainb/birdbrain/master?filepath=Index.ipynb) which should take no Python experience to use (just running cells in a Jupyter notebook). The demo uses Binder, which allows you to run a Jupyter notebook in a Docker environment online. It can take a few minutes to load, but has the benefit of not requiring you to install anything. If you want to install this software locally, the package is pip installable however (see below). 
 

--- a/birdbrain/visualization/plotting_2d.py
+++ b/birdbrain/visualization/plotting_2d.py
@@ -105,6 +105,42 @@ def plot_box_bg(ax, extent, box_size_um=2000, mn=0.2, mx=0.3):
     )
 
 
+def make_label_data(atlas, regions_to_plot, point_in_voxels):
+    label_data = {
+        r2p: {"voxels": atlas.voxel_data.loc[r2p, "voxels"]} for r2p in regions_to_plot
+    }
+    typegb = atlas.brain_labels.groupby('type_')
+    # get label data
+    for r2p in regions_to_plot:
+        label_data[r2p]["x_lab"] = label_data[r2p]["voxels"][point_in_voxels[0], :, :].squeeze()
+        label_data[r2p]["y_lab"] = label_data[r2p]["voxels"][:, point_in_voxels[1], :].squeeze()
+        label_data[r2p]["z_lab"] = label_data[r2p]["voxels"][:, :, point_in_voxels[2]].squeeze()
+
+        # subset labels dataframe for only the ones appearing here
+        label_data[r2p]["unique_labels"] = np.unique(np.concatenate(
+            [label_data[r2p][dim + "_lab"].flatten() for dim in 'xyz']))
+        label_data[r2p]["unique_index"] = typegb.get_group(r2p).loc[typegb.get_group(
+            r2p)['label'].isin(label_data[r2p]["unique_labels"])].index
+    regions_plotted = atlas.brain_labels.loc[np.concatenate(
+        [label_data[r2p]["unique_index"] for r2p in regions_to_plot])].copy()
+    return label_data, regions_plotted
+
+
+def update_color_labels(regions_plotted, label_data, init_color_ind=0):
+    # reset values of xlab, ylab, zlab, and regions_plotted
+    color_ind = init_color_ind
+    for r2p, type_group in regions_plotted.groupby('type_'):
+        for region, row in type_group.iterrows():
+            region_lable = row['label']
+            for dim in 'xyz':
+                label_data[r2p][dim + "_lab"][
+                    label_data[r2p][dim + "_lab"] == region_lable
+                ] = color_ind
+            regions_plotted.loc[region, "label"] = color_ind
+            color_ind += 1
+    return color_ind
+
+
 def plot_2d_coordinates(
     atlas,
     point_in_voxels=None,
@@ -143,10 +179,6 @@ def plot_2d_coordinates(
     # print the point in um
     print({inverse_dict(atlas.axes_dict)[i]: int(point_in_um[i]) for i in range(3)})
 
-    # the type of image to plot
-    label_data = {
-        r2p: {"voxels": atlas.voxel_data.loc[r2p, "voxels"]} for r2p in regions_to_plot
-    }
     brain_data = atlas.voxel_data.loc["Brain", "voxels"]
 
     zero_point = um_to_vox(
@@ -200,64 +232,8 @@ def plot_2d_coordinates(
         y_img_masked = brain_masked_img_data[:, point_in_voxels[1], :].squeeze()
         z_img_masked = brain_masked_img_data[:, :, point_in_voxels[2]].squeeze()
 
-    # get label data
-    for r2p in regions_to_plot:
-        x_lab = label_data[r2p]["voxels"][point_in_voxels[0], :, :].squeeze()
-        y_lab = label_data[r2p]["voxels"][:, point_in_voxels[1], :].squeeze()
-        z_lab = label_data[r2p]["voxels"][:, :, point_in_voxels[2]].squeeze()
-
-        # subset labels dataframe for only the ones appearing here
-        unique_labels = np.unique(
-            list(x_lab.flatten()) + list(y_lab.flatten()) + list(z_lab.flatten())
-        )
-
-        label_data[r2p]["x_lab"] = x_lab
-        label_data[r2p]["y_lab"] = y_lab
-        label_data[r2p]["z_lab"] = z_lab
-        label_data[r2p]["unique_labels"] = unique_labels
-
-    # subset brain_labels dataframe for only the labels shown here
-    regions_plotted = pd.concat(
-        [
-            atlas.brain_labels[
-                (atlas.brain_labels.type_ == r2p)
-                & (
-                    [
-                        label in label_data[r2p]["unique_labels"]
-                        for label in atlas.brain_labels.label.values
-                    ]
-                )
-            ]
-            for r2p in regions_to_plot
-        ]
-    )
-
-    regions_plotted.index = np.arange(len(regions_plotted))
-    # reset values of xlab, ylab, zlab, and regions_plotted
-    colors_plotted = 1  # the number of colors plotted so far
-    for r2p in regions_to_plot:
-        # get regions plotted in this r2p
-        regions = regions_plotted[regions_plotted.type_.values == r2p].region.values
-        # for each of those regions, change the values of x_lab, y_lab, z_lab
-        for region in regions:
-            reg_lab = regions_plotted[
-                regions_plotted.region.values == region
-            ].label.values[0]
-            label_data[r2p]["x_lab"][
-                label_data[r2p]["x_lab"] == reg_lab
-            ] = colors_plotted
-            label_data[r2p]["y_lab"][
-                label_data[r2p]["y_lab"] == reg_lab
-            ] = colors_plotted
-            label_data[r2p]["z_lab"][
-                label_data[r2p]["z_lab"] == reg_lab
-            ] = colors_plotted
-            # change the value of regions_plotted.label
-            regions_plotted.loc[
-                regions_plotted.region.values == region, "label"
-            ] = colors_plotted
-            # update to next color
-            colors_plotted += 1
+    label_data, regions_plotted = make_label_data(atlas, regions_to_plot, point_in_voxels)
+    _ = update_color_labels(regions_plotted, label_data, init_color_ind=1)
 
     # normalize colors to regions being plotted
     if len(regions_plotted) > 0:

--- a/testing/test_make_atlas.py
+++ b/testing/test_make_atlas.py
@@ -1,3 +1,9 @@
+import os
+import matplotlib as mpl
+if os.environ.get('DISPLAY', '') == '':
+    print('no display found. Using non-interactive Agg backend')
+    mpl.use('Agg')
+
 from birdbrain.atlas import atlas
 from birdbrain.visualization.plotting_2d import plot_transection, plot_2d_coordinates
 

--- a/testing/test_make_atlas.py
+++ b/testing/test_make_atlas.py
@@ -1,11 +1,5 @@
-import sys
 from birdbrain.atlas import atlas
-from birdbrain.utils import um_to_vox
-import numpy as np
-from birdbrain.visualization.plotting_3d import plot_regions_3d, rotate_plot
 from birdbrain.visualization.plotting_2d import plot_transection, plot_2d_coordinates
-
-REQUIRED_PYTHON = "python3"
 
 
 def test_make_atlas():

--- a/testing/test_plot_2d.py
+++ b/testing/test_plot_2d.py
@@ -1,0 +1,133 @@
+from birdbrain.atlas import atlas
+import pytest
+import numpy as np
+import pandas as pd
+from birdbrain.visualization.plotting_2d import plot_transection, plot_2d_coordinates, make_label_data, update_color_labels
+from birdbrain.utils import um_to_vox
+import copy
+
+
+@pytest.fixture(scope="module")
+def starling_atlas():
+    dset_dir = "../../data/processed/starling/"
+    return atlas(
+        species="starling",
+        dset_dir=dset_dir,
+        um_mult=100,
+        smoothing=[],  # ['Brain', 'Brainregions']
+    )
+
+
+def test_plot_2d_coordinates(starling_atlas):
+    plot_2d_coordinates(starling_atlas, point_in_um=[0, 0, 0])
+
+
+def old_make_label_data(atlas, regions_to_plot, point_in_voxels):
+    label_data = {
+        r2p: {"voxels": atlas.voxel_data.loc[r2p, "voxels"]} for r2p in regions_to_plot
+    }
+    # get label data
+    for r2p in regions_to_plot:
+        x_lab = label_data[r2p]["voxels"][point_in_voxels[0], :, :].squeeze()
+        y_lab = label_data[r2p]["voxels"][:, point_in_voxels[1], :].squeeze()
+        z_lab = label_data[r2p]["voxels"][:, :, point_in_voxels[2]].squeeze()
+
+        # subset labels dataframe for only the ones appearing here
+        unique_labels = np.unique(
+            list(x_lab.flatten()) + list(y_lab.flatten()) + list(z_lab.flatten())
+        )
+
+        label_data[r2p]["x_lab"] = x_lab
+        label_data[r2p]["y_lab"] = y_lab
+        label_data[r2p]["z_lab"] = z_lab
+        label_data[r2p]["unique_labels"] = unique_labels
+
+    # subset brain_labels dataframe for only the labels shown here
+    regions_plotted = pd.concat(
+        [
+            atlas.brain_labels[
+                (atlas.brain_labels.type_ == r2p)
+                & (
+                    [
+                        label in label_data[r2p]["unique_labels"]
+                        for label in atlas.brain_labels.label.values
+                    ]
+                )
+            ]
+            for r2p in regions_to_plot
+        ]
+    )
+    # this doesn't seem like its ever used...
+    # regions_plotted.index = np.arange(len(regions_plotted))
+    return label_data, regions_plotted
+
+
+@pytest.mark.parametrize("regions_to_plot", [["Brainregions"], ["Brainregions", "Nuclei"]])
+def test_make_label_data(starling_atlas, regions_to_plot):
+    point_in_um = [0, 1500, -200]
+    point_in_voxels = np.array(
+        um_to_vox(
+            point_in_um,
+            starling_atlas.voxel_data.loc["Brain", "affine"],
+            starling_atlas.um_mult,
+            starling_atlas.y_sinus_um_transform,
+        )
+    )
+    label_data, regions_plotted = make_label_data(starling_atlas, regions_to_plot, point_in_voxels)
+    old_label_data, old_regions_plotted = old_make_label_data(
+        starling_atlas, regions_to_plot, point_in_voxels)
+    assert len(regions_plotted) == len(old_regions_plotted)
+    assert len(label_data) == len(old_label_data)
+    for r2p in label_data:
+        assert np.all(label_data[r2p]['unique_labels'] == old_label_data[r2p]['unique_labels'])
+
+
+def old_update_color_labels(regions_plotted, label_data, regions_to_plot, init_color_ind=1):
+    # reset values of xlab, ylab, zlab, and regions_plotted
+    colors_plotted = init_color_ind  # the number of colors plotted so far
+    for r2p in regions_to_plot:
+        # get regions plotted in this r2p
+        regions = regions_plotted[regions_plotted.type_.values == r2p].region.values
+        # for each of those regions, change the values of x_lab, y_lab, z_lab
+        for region in regions:
+            reg_lab = regions_plotted[
+                regions_plotted.region.values == region
+            ].label.values[0]
+            label_data[r2p]["x_lab"][
+                label_data[r2p]["x_lab"] == reg_lab
+            ] = colors_plotted
+            label_data[r2p]["y_lab"][
+                label_data[r2p]["y_lab"] == reg_lab
+            ] = colors_plotted
+            label_data[r2p]["z_lab"][
+                label_data[r2p]["z_lab"] == reg_lab
+            ] = colors_plotted
+            # change the value of regions_plotted.label
+            regions_plotted.loc[
+                regions_plotted.region.values == region, "label"
+            ] = colors_plotted
+            # update to next color
+            colors_plotted += 1
+    return colors_plotted
+
+
+@pytest.mark.parametrize("regions_to_plot", [["Brainregions"], ["Brainregions", "Nuclei"]])
+def test_update_color_labels(starling_atlas, regions_to_plot):
+    point_in_um = [0, 1500, -200]
+    point_in_voxels = np.array(
+        um_to_vox(
+            point_in_um,
+            starling_atlas.voxel_data.loc["Brain", "affine"],
+            starling_atlas.um_mult,
+            starling_atlas.y_sinus_um_transform,
+        )
+    )
+    label_data, regions_plotted = make_label_data(starling_atlas, regions_to_plot, point_in_voxels)
+    old_label_data = copy.deepcopy(label_data)
+    old_regions_plotted = copy.deepcopy(regions_plotted)
+
+    color_ind = update_color_labels(regions_plotted, label_data, init_color_ind=1)
+    old_color_ind = old_update_color_labels(
+        old_regions_plotted, old_label_data, regions_to_plot, init_color_ind=1)
+
+    assert color_ind == old_color_ind


### PR DESCRIPTION
I'll leave this PR open for now re: python 2 compatibility.

It seems to be having an issue with k3d.volume

Here's the environment:
https://travis-ci.com/MarvinT/birdbrain/jobs/179581305

This is the stacktrace:
```
Input:
plot, vec  = plot_regions_3d(starling_atlas, regions_to_plot = nuclei+tracts, downsample_pct = 1, polygon_simplification = 0, verbose=False)
Traceback:
TypeErrorTraceback (most recent call last)
<ipython-input-9-794d66952dd4> in <module>()
----> 1 plot, vec  = plot_regions_3d(starling_atlas, regions_to_plot = nuclei+tracts, downsample_pct = 1, polygon_simplification = 0, verbose=False)
/home/travis/build/MarvinT/birdbrain/birdbrain/visualization/plotting_3d.py in plot_regions_3d(atlas, regions_to_plot, downsample_pct, polygon_simplification, verbose)
    101         alpha_coef=0.25,
    102         bounds=bounds,
--> 103         compression_level=9,
    104     )
    105 
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/k3d/k3d.pyc in volume(volume, color_map, color_range, samples, alpha_coef, gradient_step, shadow, shadow_delay, shadow_res, compression_level, **kwargs)
    690         Volume(volume=volume, color_map=color_map, color_range=color_range, compression_level=compression_level,
    691                samples=samples, alpha_coef=alpha_coef, gradient_step=gradient_step, shadow=shadow,
--> 692                shadow_delay=shadow_delay, shadow_res=shadow_res),
    693         **kwargs)
    694 
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/k3d/objects.pyc in __init__(self, **kwargs)
    710 
    711     def __init__(self, **kwargs):
--> 712         super(Volume, self).__init__(**kwargs)
    713 
    714         self.set_trait('type', 'Volume')
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/k3d/objects.pyc in __init__(self, **kwargs)
     45         self.id = id(self)
     46 
---> 47         super(Drawable, self).__init__(**kwargs)
     48 
     49     def __iter__(self):
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/ipywidgets/widgets/widget.pyc in __init__(self, **kwargs)
    412 
    413         Widget._call_widget_constructed(self)
--> 414         self.open()
    415 
    416     def __del__(self):
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/ipywidgets/widgets/widget.pyc in open(self)
    425         """Open a comm to the frontend if one isn't already open."""
    426         if self.comm is None:
--> 427             state, buffer_paths, buffers = _remove_buffers(self.get_state())
    428 
    429             args = dict(target_name='jupyter.widget',
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/ipywidgets/widgets/widget.pyc in get_state(self, key, drop_defaults)
    510         for k in keys:
    511             to_json = self.trait_metadata(k, 'to_json', self._trait_to_json)
--> 512             value = to_json(getattr(self, k), self)
    513             if not PY3 and isinstance(traits[k], Bytes) and isinstance(value, bytes):
    514                 value = memoryview(value)
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/k3d/helpers.pyc in to_json(input, obj, force_contiguous)
     58         return [to_json(i, obj) for i in input]
     59     elif isinstance(input, np.ndarray):
---> 60         return array_to_binary(input, obj, force_contiguous)
     61     else:
     62         return input
/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/k3d/helpers.pyc in array_to_binary(ar, obj, force_contiguous)
     34 
     35     if obj.compression_level > 0:
---> 36         return {'compressed_buffer': zlib.compress(memoryview(ar), obj.compression_level), 'dtype': str(ar.dtype),
     37                 'shape': ar.shape}
     38     else:
TypeError: compress() argument 1 must be string or read-only buffer, not memoryview
```